### PR TITLE
Adding a simple extensibility point for custom responses.

### DIFF
--- a/Owin.HealthCheck/HealthCheckMiddleware.cs
+++ b/Owin.HealthCheck/HealthCheckMiddleware.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Owin.HealthCheck

--- a/Owin.HealthCheck/IResponseWriter.cs
+++ b/Owin.HealthCheck/IResponseWriter.cs
@@ -3,6 +3,9 @@
     /// <summary>The Response Writer interface.</summary>
     public interface IResponseWriter
     {
+        /// <summary>Gets the HTTP content type.</summary>
+        string ContentType { get; }
+
         /// <summary>Formats the response to the client.</summary>
         /// <param name="results">The results.</param>
         /// <returns>The <see cref="string"/>.</returns>

--- a/Owin.HealthCheck/IResponseWriter.cs
+++ b/Owin.HealthCheck/IResponseWriter.cs
@@ -1,0 +1,11 @@
+﻿namespace Owin.HealthCheck
+{
+    /// <summary>The Response Writer interface.</summary>
+    public interface IResponseWriter
+    {
+        /// <summary>Formats the response to the client.</summary>
+        /// <param name="results">The results.</param>
+        /// <returns>The <see cref="string"/>.</returns>
+        string WriteResponse(dynamic results);
+    }
+}

--- a/Owin.HealthCheck/Owin.HealthCheck.csproj
+++ b/Owin.HealthCheck/Owin.HealthCheck.csproj
@@ -58,9 +58,11 @@
     <Compile Include="HealthCheckStatus.cs" />
     <Compile Include="HttpHealthCheck.cs" />
     <Compile Include="IHealthCheck.cs" />
+    <Compile Include="IResponseWriter.cs" />
     <Compile Include="OwinExtensions.cs" />
     <Compile Include="PingHealthCheck.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SimpleResponseWriter.cs" />
     <Compile Include="SqlHealthCheck.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Owin.HealthCheck/SimpleResponseWriter.cs
+++ b/Owin.HealthCheck/SimpleResponseWriter.cs
@@ -1,0 +1,17 @@
+﻿namespace Owin.HealthCheck
+{
+    using System.Text;
+
+    /// <summary>Writes the health checks as a simple key/value pair string.</summary>
+    internal class SimpleResponseWriter : IResponseWriter
+    {
+        /// <inheritdoc />
+        public string WriteResponse(dynamic results)
+        {
+            var sb = new StringBuilder();
+            foreach (var r in results)
+                sb.AppendLine(r.Name + ": " + r.Status.Message);
+            return sb.ToString();
+        }
+    }
+}

--- a/Owin.HealthCheck/SimpleResponseWriter.cs
+++ b/Owin.HealthCheck/SimpleResponseWriter.cs
@@ -6,6 +6,9 @@
     internal class SimpleResponseWriter : IResponseWriter
     {
         /// <inheritdoc />
+        public string ContentType { get; } = "text/plain";
+
+        /// <inheritdoc />
         public string WriteResponse(dynamic results)
         {
             var sb = new StringBuilder();


### PR DESCRIPTION
This allows the developer override the default response writer (key/value pair) when `debug=true` with a custom formatter.  Useful for consuming the responses in other systems that expect an specific format.